### PR TITLE
replace Collections.swap() with Kotlin's 'also'

### DIFF
--- a/src/main/kotlin/codecollection/algorithms/SelectionSort.kt
+++ b/src/main/kotlin/codecollection/algorithms/SelectionSort.kt
@@ -1,7 +1,5 @@
 package codecollection.algorithms
 
-import java.util.Collections
-
 fun selectionSort(list: List<Int>): List<Int> {
     if (list.size <= 1) return list
     val result = list.toMutableList()

--- a/src/main/kotlin/codecollection/algorithms/SelectionSort.kt
+++ b/src/main/kotlin/codecollection/algorithms/SelectionSort.kt
@@ -10,7 +10,7 @@ fun selectionSort(list: List<Int>): List<Int> {
         for (j in i + 1 until result.size) {
             if (result[j] < result[minIndex]) minIndex = j
         }
-        if (minIndex != i) Collections.swap(result, minIndex, i)
+        if (minIndex != i) result[minIndex] = result[i].also { result[i] = result[minIndex] }
     }
     return result
 }


### PR DESCRIPTION
Replace Collections.swap() with Kotlin's `also` for more idiomatic swapping.

Refactoring #2 
